### PR TITLE
Fix problem with db:create

### DIFF
--- a/lib/validates_by_schema.rb
+++ b/lib/validates_by_schema.rb
@@ -11,6 +11,10 @@ module ValidatesBySchema
       customized_columns(options).each do |c|
         ValidationOption.new(self, c).define!
       end
+
+    rescue ::ActiveRecord::NoDatabaseError
+      # Since `db:create` and other tasks from Rails 5.2.0 might load models,
+      # we need to swallow this error to execute `db:create` properly.
     end
 
     private


### PR DESCRIPTION
With newer versions of Rails a new problem occurs when trying to create the development database.
When we start `rails db:create`, the Rails application is initialized. We use devise, and when initializing the devise routes the `User` class is interpreted. The call to `table_exists?` in `validates_by_schema` attempts to connect to the database. This fails since we don't have that database, yet. Hence we can't use Rails to create a database. So we are stuck.

The proposed workaround is to silently ignore this problem and initialize the affected model without the `validates_by_schema` validator. This allows to execute `rails db:create` with newer versions of Rails, too.

This workaround is suboptimal since we might be executing another rake task with the same command. That other rake task can't rely on the validation. This gem has been fine with this approach so far, as it does the same thing when the database exists but the model's table is missing.

HTH