### PR TITLE
Skip presence validation when default value is set

### DIFF
--- a/lib/validates_by_schema/validation_option.rb
+++ b/lib/validates_by_schema/validation_option.rb
@@ -36,7 +36,7 @@ class ValidatesBySchema::ValidationOption
   end
 
   def presence?
-    presence && column.type != :boolean
+    presence && column.type != :boolean && column.default.nil?
   end
 
   def presence

--- a/spec/config/schema.rb
+++ b/spec/config/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20_121_210_034_140) do
     t.integer 'other_id'
     t.integer 'kind',                                                null: false
     t.string 'list', array: true, limit: 3
+    t.string 'fallback', default: 'value', null: false
 
     t.index 'parent_id'
     t.index ['name', 'wheels'], unique: true

--- a/spec/validations_spec.rb
+++ b/spec/validations_spec.rb
@@ -33,6 +33,7 @@ describe 'validates by schema' do
         it { should_not validate_presence_of(:name) }
         it { should validate_length_of(:name).is_at_most(50) }
         it { should validate_presence_of(:model) }
+        it { should_not validate_presence_of(:fallback) }
         if ENV['DB'] == 'mysql'
           it { should validate_length_of(:model).is_at_most(255) }
         end


### PR DESCRIPTION
When I got a schema defined default value for a not-null column, presence validation should be skipped to let the db use its default value.